### PR TITLE
Add RedactQueryStringValueTelemetryProcessor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Ubuntu2004
 
 cache:
   - tools -> build.ps1

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet.org" value="https://nuget.org/api/v2/" />
+  </packageSources>
+</configuration>

--- a/src/RimDev.ApplicationInsights.Filters/InternalsVisibleTo.cs
+++ b/src/RimDev.ApplicationInsights.Filters/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("RimDev.ApplicationInsights.Filters.Tests")]

--- a/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessor.cs
+++ b/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessor.cs
@@ -41,7 +41,7 @@ namespace RimDev.ApplicationInsights.Filters.Processors
             if (telemetryItem is RequestTelemetry request && request.Url != null)
             {
                 var uri = request.Url;
-                _options.Names = _options.Names ?? Array.Empty<string>();
+                _options.Keys = _options.Keys ?? Array.Empty<string>();
 
                 // https://stackoverflow.com/a/43407008
                 // ParseQuery() uses KeyValueAccumulator() which does case-insensitive keys
@@ -57,7 +57,7 @@ namespace RimDev.ApplicationInsights.Filters.Processors
                 foreach (var arg in queryArguments)
                 {
                     qb.Add(arg.Key,
-                        _options.Names.Contains(arg.Key, StringComparer.OrdinalIgnoreCase)
+                        _options.Keys.Contains(arg.Key, StringComparer.OrdinalIgnoreCase)
                             ? _options.RedactedValue
                             : arg.Value);
                 }

--- a/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessor.cs
+++ b/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessor.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace RimDev.ApplicationInsights.Filters.Processors
+{
+    /// <summary>Redact the value of any QueryString argument that matches
+    /// the provided list of names.  Note that the ordering of QueryString
+    /// arguments will change to alphabetical ordering after this
+    /// processor works on the QueryString argument collection.
+    /// Matching of argument names is case insensitive (see <see cref="QueryHelpers.ParseQuery"/>).
+    /// </summary>
+    public class RedactQueryStringValueTelemetryProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor _next;
+        private readonly RedactQueryStringValueTelemetryProcessorOptions _options;
+
+        public RedactQueryStringValueTelemetryProcessor(
+            ITelemetryProcessor next,
+            RedactQueryStringValueTelemetryProcessorOptions options
+            )
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+
+            _next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            RedactTelemetryItem(item);
+            _next.Process(item);
+        }
+
+        internal void RedactTelemetryItem(ITelemetry telemetryItem)
+        {
+            if (telemetryItem is RequestTelemetry request && request.Url != null)
+            {
+                var uri = request.Url;
+                _options.Names = _options.Names ?? Array.Empty<string>();
+
+                // https://stackoverflow.com/a/43407008
+                // ParseQuery() uses KeyValueAccumulator() which does case-insensitive keys
+                var query = QueryHelpers.ParseQuery(uri.Query);
+
+                // convert to KeyValuePair, and order on the Key (makes output more predictable)
+                var queryArguments = query.SelectMany(x => x.Value, (col, value) =>
+                    new KeyValuePair<string, string>(col.Key, value))
+                    .OrderBy(x => x.Key)
+                    .ToList();
+
+                var qb = new QueryBuilder();
+                foreach (var arg in queryArguments)
+                {
+                    qb.Add(arg.Key,
+                        _options.Names.Contains(arg.Key, StringComparer.OrdinalIgnoreCase)
+                            ? _options.RedactedValue
+                            : arg.Value);
+                }
+
+                var resultUri = new UriBuilder
+                {
+                    Scheme = uri.Scheme,
+                    Host = uri.Host,
+                    Port = uri.Port,
+                    Fragment = uri.Fragment,
+                    Path = uri.AbsolutePath,
+                    Query = qb.ToString()
+                };
+                request.Url = resultUri.Uri;
+            }
+        }
+    }
+}

--- a/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
+++ b/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
@@ -1,0 +1,13 @@
+namespace RimDev.ApplicationInsights.Filters.Processors
+{
+    public class RedactQueryStringValueTelemetryProcessorOptions
+    {
+        /// <summary>What should we replace the QueryString argument value with?</summary>
+        public string RedactedValue { get; set; } = "REDACTED";
+
+        /// <summary>List of QueryString argument names to redact.  Note that in .NET Core,
+        /// those argument names are case insensitive. (See <see cref="QueryHelpers.ParseQuery"/>.)
+        /// </summary>
+        public string[] Names { get; set; }
+    }
+}

--- a/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
+++ b/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
@@ -8,6 +8,6 @@ namespace RimDev.ApplicationInsights.Filters.Processors
         /// <summary>List of QueryString argument names to redact.  Note that in .NET Core,
         /// those argument names are case insensitive. (See <see cref="QueryHelpers.ParseQuery"/>.)
         /// </summary>
-        public string[] Names { get; set; }
+        public string[] Keys { get; set; }
     }
 }

--- a/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
+++ b/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
 

--- a/tests/RimDev.ApplicationInsights.Filters.Tests/Processors/RedactQueryStringValueTelemetryProcessorTests.cs
+++ b/tests/RimDev.ApplicationInsights.Filters.Tests/Processors/RedactQueryStringValueTelemetryProcessorTests.cs
@@ -71,7 +71,7 @@ namespace RimDev.ApplicationInsights.Filters.Tests.Processors
             ITelemetry item = CreateTelemetryItemFromAbsoluteUrl(inputAbsoluteUrl);
             var options = new RedactQueryStringValueTelemetryProcessorOptions
             {
-                Names = names,
+                Keys = names,
             };
             var sut = CreateSut(options);
 
@@ -97,7 +97,7 @@ namespace RimDev.ApplicationInsights.Filters.Tests.Processors
             ITelemetry item = CreateTelemetryItemFromAbsoluteUrl(inputAbsoluteUrl);
             var options = new RedactQueryStringValueTelemetryProcessorOptions
             {
-                Names = names,
+                Keys = names,
                 RedactedValue = "HIDDEN"
             };
             var sut = CreateSut(options);

--- a/tests/RimDev.ApplicationInsights.Filters.Tests/Processors/RedactQueryStringValueTelemetryProcessorTests.cs
+++ b/tests/RimDev.ApplicationInsights.Filters.Tests/Processors/RedactQueryStringValueTelemetryProcessorTests.cs
@@ -1,0 +1,132 @@
+using System;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+using RimDev.ApplicationInsights.Filters.Processors;
+using Xunit;
+
+namespace RimDev.ApplicationInsights.Filters.Tests.Processors
+{
+    public class RedactQueryStringValueTelemetryProcessorTests
+    {
+        [Theory]
+        [InlineData(
+            "http://www1.example.com/",
+            "http://www1.example.com/"
+            )]
+        [InlineData(
+            "https://www2.example.com:8081/?s=abc123",
+            "https://www2.example.com:8081/?s=abc123"
+            // caller passed in zero argument names
+            )]
+        [InlineData( // arguments get sorted
+            "https://www2.example.com:8081/?a=a&b=b&c=c&s=abc123&z=z",
+            "https://www2.example.com:8081/?s=abc123&z=z&c=c&a=a&b=b"
+            // caller passed in zero argument names
+            )]
+        [InlineData(
+            "https://www3.example.com:81/?s=REDACTED",
+            "https://www3.example.com:81/?s=abc",
+            "s"
+            )]
+        [InlineData(
+            "https://www4.example.com/?s=REDACTED",
+            "https://www4.example.com/?s=abc",
+            "S" // even with different case, the "s" param gets redacted
+            )]
+        [InlineData(
+            "https://www5.example.com/?s=REDACTED",
+            "https://www5.example.com/?s=abc",
+            "S", "s", "s" // caller passed in multiples
+            )]
+        [InlineData( // arguments get put in alphabetical (Ordinal) order
+            "https://www6.example.com/?s=REDACTED&SECRET=REDACTED&Zid=63643",
+            "https://www6.example.com/?Zid=63643&s=abc&SECRET=xyz",
+            "s", "secret"
+            )]
+        [InlineData(
+            "https://www7.example.com:8081/?id=173&s=REDACTED&secret=REDACTED",
+            "https://www7.example.com:8081/?id=173&secret=xyz&s=abc",
+            "S", "SECRET" // case does not matter, for multiple argument names
+            )]
+        [InlineData(
+            // mixed-case argument names get collapsed into same-case (it use the first for the others)
+            "https://www8.example.com:8081/?id=23122&s=REDACTED&secret=REDACTED&secret=REDACTED&secret=REDACTED",
+            "https://www8.example.com:8081/?id=23122&secret=xyz&s=abc&secret=21389382&SECRET=J235",
+            "s", "secret"
+            )]
+        [InlineData(
+            // mixed-case argument names get collapsed into same-case (it use the first for the others)
+            "https://www8.example.com:8081/?id=23124&s=REDACTED&SeCRet=REDACTED&SeCRet=REDACTED&SeCRet=REDACTED",
+            "https://www8.example.com:8081/?id=23124&SeCRet=xyz&s=abc&secret=21389382&SECRET=J235",
+            "s", "secret"
+            )]
+        public void RedactTelemetryItem_mutates_item_correctly(
+            string expectedAbsoluteUrl,
+            string inputAbsoluteUrl,
+            params string[] names
+            )
+        {
+            ITelemetry item = CreateTelemetryItemFromAbsoluteUrl(inputAbsoluteUrl);
+            var options = new RedactQueryStringValueTelemetryProcessorOptions
+            {
+                Names = names,
+            };
+            var sut = CreateSut(options);
+
+            sut.RedactTelemetryItem(item);
+
+            var result = ((RequestTelemetry) item).Url;
+            Assert.Equal(expectedAbsoluteUrl, result.AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData(
+            // mixed-case argument names get collapsed into same-case (it use the first for the others)
+            "https://www8.example.com:8081/?s=HIDDEN&SECRET=HIDDEN&SECRET=HIDDEN&SECRET=HIDDEN&ZZid=724",
+            "https://www8.example.com:8081/?ZZid=724&SECRET=xyz&s=abc&secret=21389382&SECRET=J235",
+            "s", "secret"
+            )]
+        public void RedactTelemetryItem_uses_RedactedValue_from_options(
+            string expectedAbsoluteUrl,
+            string inputAbsoluteUrl,
+            params string[] names
+            )
+        {
+            ITelemetry item = CreateTelemetryItemFromAbsoluteUrl(inputAbsoluteUrl);
+            var options = new RedactQueryStringValueTelemetryProcessorOptions
+            {
+                Names = names,
+                RedactedValue = "HIDDEN"
+            };
+            var sut = CreateSut(options);
+
+            sut.RedactTelemetryItem(item);
+
+            var result = ((RequestTelemetry) item).Url;
+            Assert.Equal(expectedAbsoluteUrl, result.AbsoluteUri);
+        }
+
+        private static RedactQueryStringValueTelemetryProcessor CreateSut(
+            RedactQueryStringValueTelemetryProcessorOptions options = null
+            )
+        {
+            var telemetryProcessorMock = new Mock<ITelemetryProcessor>(MockBehavior.Loose);
+            options ??= new RedactQueryStringValueTelemetryProcessorOptions();
+            var sut = new RedactQueryStringValueTelemetryProcessor(
+                telemetryProcessorMock.Object,
+                options
+                );
+            return sut;
+        }
+
+        private static RequestTelemetry CreateTelemetryItemFromAbsoluteUrl(string inputAbsoluteUrl)
+        {
+            return new RequestTelemetry
+            {
+                Url = new Uri(inputAbsoluteUrl, UriKind.Absolute),
+            };
+        }
+    }
+}

--- a/tests/RimDev.ApplicationInsights.Filters.Tests/RimDev.ApplicationInsights.Filters.Tests.csproj
+++ b/tests/RimDev.ApplicationInsights.Filters.Tests/RimDev.ApplicationInsights.Filters.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
Create an ApplicationInsights TelemetryProcessor which will redact any
sensitive QueryString argument values on the TelemetryRequest URLs
before passing them to ApplicationInsights.

This also adds dependencies on:
- Microsoft.AspNetCore.Http.Extensions
- Microsoft.AspNetCore.WebUtilities

---

Additional yak-shaving:
- Switch to the Ubuntu2004 build image (VS2017 was too old)
- Add a nuget.config file for the Cake bootstrap
