### PR TITLE
Use NuGet v3, publish symbol package (.snupkg)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ skip_tags: true
 artifacts:
   - path: ./msbuild.log
   - path: ./artifacts/*.nupkg
+  - path: ./artifacts/*.snupkg
 
 deploy:
   - provider: Environment

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="NuGet.org" value="https://nuget.org/api/v2/" />
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I failed to mark the .snupkg as an AppVeyor artifact.  Which is probably why it failed to publish to NuGet.