### PR TITLE
Be explicit that *.snupkg are NuGet packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ artifacts:
   - path: ./msbuild.log
   - path: ./artifacts/*.nupkg
   - path: ./artifacts/*.snupkg
+    type: NuGetPackage
 
 deploy:
   - provider: Environment


### PR DESCRIPTION
This is based on:

https://help.appveyor.com/discussions/questions/49442

It's also possible that we have to change some
settings on the NuGet deployment environment
inside of the AppVeyor UI.  Like telling to explicitly
point at NuGet v3.