### PR TITLE
Update README for 1.1 release versions, publish XML docs, warnings as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Application Insights Filters
 
-Filters for Microsoft Application Insights ASP.NET and ASP.NET Core applications.
+Filters to suppress or redact information being recorded into Microsoft Application Insights for ASP.NET and ASP.NET Core applications.
 
 ## Installation
 
@@ -29,6 +29,12 @@ namespace WebApplication
                     ConfigurationManager.ConnectionStrings["Hangfire"]?.ConnectionString))
                 .Use(next => new IgnorePathsTelemetry(next, "/_admin"))
                 .Use(next => new RemoveHttpUrlPasswordsTelemetry(next))
+                .Use(next => new RedactQueryStringValueTelemetryProcessor(next,
+                    new RedactQueryStringValueTelemetryProcessorOptions
+                    {
+                        RedactedValue = "REDACTED",
+                        Keys = new[] {"secret"},
+                    }))
                 .Build();
         }
 
@@ -48,6 +54,13 @@ namespace WebApplication
             services.AddApplicationInsightsTelemetryProcessor<IgnoreHangfireTelemetry>();
             services.AddApplicationInsightsTelemetryProcessor<IgnorePathsTelemetry>();
             services.AddApplicationInsightsTelemetryProcessor<RemoveHttpUrlPasswordsTelemetry>();
+
+            services.AddSingleton(new RedactQueryStringValueTelemetryProcessorOptions
+            {
+                RedactedValue = "REDACTED",
+                Keys = new[] {"secret"},
+            });
+            services.AddApplicationInsightsTelemetryProcessor<RedactQueryStringValueTelemetryProcessor>();
         }
     }
 }
@@ -56,5 +69,3 @@ namespace WebApplication
 ## License
 
 MIT License
-
-[NuGet link]: https://www.nuget.org/packages/RimDev.ApplicationInsights.Filters

--- a/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
+++ b/src/RimDev.ApplicationInsights.Filters/Processors/RedactQueryStringValueTelemetryProcessorOptions.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.WebUtilities;
+
 namespace RimDev.ApplicationInsights.Filters.Processors
 {
     public class RedactQueryStringValueTelemetryProcessorOptions

--- a/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
+++ b/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
@@ -2,13 +2,20 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Description>Filters for Microsoft Application Insights ASP.NET and ASP.NET Core applications.</Description>
+
+    <Description>Filters to suppress or redact information being logged into Microsoft Application Insights for ASP.NET and ASP.NET Core applications.</Description>
     <Authors>Ritter Insurance Marketing</Authors>
-    <Copyright>Copyright 2019 Ritter Insurance Marketing</Copyright>
+    <Copyright>Copyright 2019-2021 Ritter Insurance Marketing</Copyright>
+
     <PackageId>RimDev.ApplicationInsights.Filters</PackageId>
-    <Version>1.0.4</Version>
     <PackageProjectUrl>https://github.com/ritterim/application-insights-filters</PackageProjectUrl>
     <PackageTags>rimdev;application;insights;filters;telemetry;itelemetryprocessor</PackageTags>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/RimDev.ApplicationInsights.Filters.Tests/RimDev.ApplicationInsights.Filters.Tests.csproj
+++ b/tests/RimDev.ApplicationInsights.Filters.Tests/RimDev.ApplicationInsights.Filters.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- The build number from AppVeyor now appears
as the 3rd position on the major.minor.patch value.
- v1.1 Adds RedactQueryStringValueTelemetryProcessorOptions
- Adjust the package description, add example for new filter.
- Turn on TreatWarningsAsErrors in the csproj files, plus
publish both symbols and XML documentation.