### PR TITLE
Force System.Text.Encodings.Web >= 4.5.1

### DIFF
--- a/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
+++ b/src/RimDev.ApplicationInsights.Filters/RimDev.ApplicationInsights.Filters.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There is a vulnerability in 4.5.0 (which is referenced
by Microsoft.AspNetCore.WebUtilities@2.2.0 and
Microsoft.AspNetCore.Http.Extensions@2.2.0.

But there's no newer version of those dependencies that
references a fixed version.

That means we have to force this project to use 4.5.1 of
the vulnerable package.